### PR TITLE
Add test leagues page

### DIFF
--- a/pages/league/[leagueid].jsx
+++ b/pages/league/[leagueid].jsx
@@ -1,0 +1,21 @@
+import { useRouter } from 'next/router';
+import React, { useEffect, useState } from 'react';
+
+export default function Leagues() {
+  const router = useRouter();
+  const [id, setId] = useState(null);
+
+  useEffect(() => {
+    const { query: { leagueid = null } = {} } = router;
+
+    if (leagueid) {
+      setId(leagueid);
+    }
+  }, [router]);
+
+  return (
+    <div>
+      {id}
+    </div>
+  );
+}


### PR DESCRIPTION
Add leagues page with dynamic routes. Want to see if Netlify will still generate a single static page, and that the leagueid is passed as a query parameter.